### PR TITLE
Use rash_alt gem instead of rash gem

### DIFF
--- a/jp_zip_code.gemspec
+++ b/jp_zip_code.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'rubyzip'
-  spec.add_dependency 'rash'
+  spec.add_dependency 'rash_alt'
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'

--- a/lib/jp_zip_code.rb
+++ b/lib/jp_zip_code.rb
@@ -12,7 +12,7 @@ module JpZipCode
     json_file = "#{File.dirname(__FILE__)}/../data/zip_code/#{zip_code[0, 4]}.json"
     if File.exist?(json_file)
       data = File.open(json_file) { |json| JSON.load(json) }
-      Hashie::Rash.new(convert(data[zip_code])) if data[zip_code]
+      Hashie::Mash::Rash.new(convert(data[zip_code])) if data[zip_code]
     end
   end
 


### PR DESCRIPTION
Hi!
To update hashie dependency version,  use `rash_alt` gem!
Because rash gem is not maintained now and it's dependency is `'hashie', '~> 2.0.0'`.
Please review!